### PR TITLE
Bugfix: typescript not compiling, wrong type definition file.

### DIFF
--- a/DynamicKey/AgoraDynamicKey/nodejs/index.d.ts
+++ b/DynamicKey/AgoraDynamicKey/nodejs/index.d.ts
@@ -87,6 +87,3 @@ export namespace RtmTokenBuilder {
      */
     export function buildToken(appID: string, appCertificate: string, account: string | number, role: number, privilegeExpiredTs: number): string;
 }
-
-module.exports.RtmTokenBuilder = RtmTokenBuilder
-module.exports.Role = Role


### PR DESCRIPTION
Compiling any ts project that uses the agora-access-token module fails with

`TS1036: Statements are not allowed in ambient contexts.`

and

`TS2304: Cannot find name 'Role'`

Reason was a faulty index.d.ts. Seems like some copy-paste left overs.