### PR TITLE
fix variable name userAccount

### DIFF
--- a/DynamicKey/AgoraDynamicKey/go/src/RtmTokenBuilder/RtmTokenBuilder.go
+++ b/DynamicKey/AgoraDynamicKey/go/src/RtmTokenBuilder/RtmTokenBuilder.go
@@ -21,15 +21,15 @@ type RtmTokenBuilder struct {
 //        Agora Dashboard if it is missing from your kit. See Get an App ID.
 // appCertificate:	Certificate of the application that you registered in
 //                  the Agora Dashboard. See Get an App Certificate.
-// userAccount: The user account.
+// channelName:Unique channel name for the AgoraRTC session in the string format.
 // role: Role_Rtm_User = 1
 // privilegeExpireTs: represented by the number of seconds elapsed since
 //                    1/1/1970. If, for example, you want to access the
 //                    Agora Service within 10 minutes after the token is
 //                    generated, set expireTimestamp as the current
 //                    timestamp + 600 (seconds)./
-func BuildToken(appID string, appCertificate string, userAccount string, role Role, privilegeExpiredTs uint32) (string, error) {
-	token := accesstoken.CreateAccessToken2(appID, appCertificate, userAccount, "")
+func BuildToken(appID string, appCertificate string, channelName string, role Role, privilegeExpiredTs uint32) (string, error) {
+	token := accesstoken.CreateAccessToken2(appID, appCertificate, channelName, "")
 	token.AddPrivilege(accesstoken.KLoginRtm, privilegeExpiredTs)
 	return token.Build()
 }


### PR DESCRIPTION
- The variable name userAccount in `rtmtokenbuilder.BuildToken` should be changed to channelName. Otherwise it may cause a misleading.  Variable name in `accesstoken.CreateAccessToken2` is channelName.