### PR TITLE
Fix pack_map in dynamic_key5.rb

### DIFF
--- a/DynamicKey/AgoraDynamicKey/ruby/src/dynamic_key5.rb
+++ b/DynamicKey/AgoraDynamicKey/ruby/src/dynamic_key5.rb
@@ -183,7 +183,7 @@ module DynamicKey5
   def pack_map(m)
     ret = pack_uint16(m.size)
     m.each do |k, v|
-      pack_uint16(k) + pack_string(v.to_s)
+      ret += pack_uint16(k) + pack_string(v.to_s)
     end
     ret
   end


### PR DESCRIPTION
# What
- fix `pack_map` in dynamic_key5.rb
- In other languages([python](https://github.com/AgoraIO/Tools/blob/master/DynamicKey/AgoraDynamicKey/python/src/DynamicKey5.py#L155-L159) or [golang](https://github.com/AgoraIO/Tools/blob/master/DynamicKey/AgoraDynamicKey/go/src/DynamicKey5/DynamicKey5.go#L166-L186)), `pack_map` packs keys and values of the map. However, [dynamic_key5.rb](https://github.com/AgoraIO/Tools/blob/master/DynamicKey/AgoraDynamicKey/ruby/src/dynamic_key5.rb#L183-L189) doesn't pack keys and values

# Test
- In local env, test passed

```bash
bundle exec rspec dynamic_key5_test.rb                                                                                                                                                                                   
signature:929C9E46187A022BAAB26B7BF018438C675CFE1A
.public sharing key:005AwAoADc0QTk5RTVEQjI4MDk0NUI0NzUwNTk0MUFDMjM4MDU2NzIwREY3QjAQAJcMo13mDERkW7roohUGGzOwKDdW9buDA68oN1YAAA==
.public recording key:005AgAoADkyOUM5RTQ2MTg3QTAyMkJBQUIyNkI3QkYwMTg0MzhDNjc1Q0ZFMUEQAJcMo13mDERkW7roohUGGzOwKDdW9buDA68oN1YAAA==
.public media channel key:005AQAoAEJERTJDRDdFNkZDNkU0ODYxNkYxQTYwOUVFNTM1M0U5ODNCQjFDNDQQAJcMo13mDERkW7roohUGGzOwKDdW9buDA68oN1YAAA==
.no_upload:005BAAoADgyNEQxNDE4M0FGRDkyOEQ4REFFMUU1OTg5NTg2MzA3MTEyNjRGNzQQAJcMo13mDERkW7roohUGGzOwKDdW9buDA68oN1YBAAEAAQAw
audio_video_upload:005BAAoADJERDA3QThENTE2NzJGNjQwMzY5NTFBNzE0QkI5NTc0N0Q1QjZGQjMQAJcMo13mDERkW7roohUGGzOwKDdW9buDA68oN1YBAAEAAQAz
.

Finished in 0.00288 seconds (files took 0.10989 seconds to load)
5 examples, 0 failures
```