### PR TITLE
Add docs to AgoraDynamicKey::RTCTokenBuilder.build_token_with_account

### DIFF
--- a/DynamicKey/AgoraDynamicKey/ruby/lib/dynamic_key/rtc_token_builder.rb
+++ b/DynamicKey/AgoraDynamicKey/ruby/lib/dynamic_key/rtc_token_builder.rb
@@ -51,6 +51,7 @@ module AgoraDynamicKey
         build_token_with_account @params.merge(:account => @params[:uid])
       end
 
+      # NOT RECOMMENDED
       #
       # Builds an RTC token using a string user_account.
       # @param payload


### PR DESCRIPTION
As explained in the official doc( https://docs.agora.io/en/Interactive%20Broadcast/token_server?platform=iOS#api-reference )

> Agora also provides a buildTokenWithUserAccount method which enables you to generate a token with a user account in the string format, though we recommend not using it.

Looks like this method isn't recommended now