### PR TITLE
Add rtns service type for AccessToken2

### DIFF
--- a/DynamicKey/AgoraDynamicKey/cpp/src/AccessToken2.h
+++ b/DynamicKey/AgoraDynamicKey/cpp/src/AccessToken2.h
@@ -46,12 +46,6 @@ class Service {
  public:
   uint16_t type_;
   std::map<uint16_t, uint32_t> privileges_;
-
- private:
-  Service(const Service &) = delete;
-  Service(Service &&) = delete;
-  Service &operator=(const Service &) = delete;
-  Service &operator=(Service &&) = delete;
 };
 
 class ServiceRtc : public Service {

--- a/DynamicKey/AgoraDynamicKey/cpp/src/AccessToken2.h
+++ b/DynamicKey/AgoraDynamicKey/cpp/src/AccessToken2.h
@@ -174,6 +174,27 @@ class ServiceStreaming : public Service {
   std::string account_;
 };
 
+class ServiceRtns : public Service {
+ public:
+  enum {
+    kServiceType = 4,
+  };
+
+  ServiceRtns() : Service(kServiceType) {}
+
+  virtual std::string PackService() override { return Pack(this); }
+  virtual void UnpackService(Unpacker *unpacker) override { *unpacker >> this; }
+
+  friend agora::tools::Packer &operator<<(agora::tools::Packer &p,
+                                          const ServiceRtns *x) {
+    return p << dynamic_cast<const Service *>(x);
+  }
+  friend agora::tools::Unpacker &operator>>(agora::tools::Unpacker &p,
+                                            ServiceRtns *x) {
+    return p >> dynamic_cast<Service *>(x);
+  }
+};
+
 template <class T>
 struct ServiceCreator {
   static Service *New() { return (new T()); }
@@ -182,6 +203,7 @@ static const std::map<uint16_t, Service *(*)()> kServiceCreator = {
     {ServiceRtc::kServiceType, ServiceCreator<ServiceRtc>::New},
     {ServiceRtm::kServiceType, ServiceCreator<ServiceRtm>::New},
     {ServiceStreaming::kServiceType, ServiceCreator<ServiceStreaming>::New},
+    {ServiceRtns::kServiceType, ServiceCreator<ServiceRtns>::New},
 };
 
 class AccessToken2 {

--- a/DynamicKey/AgoraDynamicKey/cpp/src/AccessToken2.h
+++ b/DynamicKey/AgoraDynamicKey/cpp/src/AccessToken2.h
@@ -31,6 +31,8 @@ class Service {
 
   virtual void UnpackService(Unpacker *unpacker) = 0;
 
+  virtual std::unique_ptr<Service> Clone() const = 0;
+
   friend agora::tools::Packer &operator<<(agora::tools::Packer &p,
                                           const Service *x) {
     p << x->type_ << x->privileges_;
@@ -46,6 +48,12 @@ class Service {
  public:
   uint16_t type_;
   std::map<uint16_t, uint32_t> privileges_;
+
+ protected:
+  Service(const Service &) = default;
+  Service(Service &&) = default;
+  Service &operator=(const Service &) = default;
+  Service &operator=(Service &&) = default;
 };
 
 class ServiceRtc : public Service {
@@ -76,6 +84,10 @@ class ServiceRtc : public Service {
 
   virtual void UnpackService(Unpacker *unpacker) override { *unpacker >> this; }
 
+  virtual std::unique_ptr<Service> Clone() const {
+    return std::unique_ptr<Service>(new ServiceRtc(*this));
+  }
+
   friend agora::tools::Packer &operator<<(agora::tools::Packer &p,
                                           const ServiceRtc *x) {
     p << dynamic_cast<const Service *>(x) << x->channel_name_ << x->account_;
@@ -91,6 +103,12 @@ class ServiceRtc : public Service {
  public:
   std::string channel_name_;
   std::string account_;
+
+ protected:
+  ServiceRtc(const ServiceRtc &) = default;
+  ServiceRtc(ServiceRtc &&) = default;
+  ServiceRtc &operator=(const ServiceRtc &) = default;
+  ServiceRtc &operator=(ServiceRtc &&) = default;
 };
 
 class ServiceRtm : public Service {
@@ -109,6 +127,10 @@ class ServiceRtm : public Service {
 
   virtual void UnpackService(Unpacker *unpacker) override { *unpacker >> this; }
 
+  virtual std::unique_ptr<Service> Clone() const {
+    return std::unique_ptr<Service>(new ServiceRtm(*this));
+  }
+
   friend agora::tools::Packer &operator<<(agora::tools::Packer &p,
                                           const ServiceRtm *x) {
     p << dynamic_cast<const Service *>(x) << x->user_id_;
@@ -123,6 +145,12 @@ class ServiceRtm : public Service {
 
  public:
   std::string user_id_;
+
+ protected:
+  ServiceRtm(const ServiceRtm &) = default;
+  ServiceRtm(ServiceRtm &&) = default;
+  ServiceRtm &operator=(const ServiceRtm &) = default;
+  ServiceRtm &operator=(ServiceRtm &&) = default;
 };
 
 class ServiceStreaming : public Service {
@@ -151,6 +179,10 @@ class ServiceStreaming : public Service {
 
   virtual void UnpackService(Unpacker *unpacker) override { *unpacker >> this; }
 
+  virtual std::unique_ptr<Service> Clone() const {
+    return std::unique_ptr<Service>(new ServiceStreaming(*this));
+  }
+
   friend agora::tools::Packer &operator<<(agora::tools::Packer &p,
                                           const ServiceStreaming *x) {
     p << dynamic_cast<const Service *>(x) << x->channel_name_ << x->account_;
@@ -166,6 +198,12 @@ class ServiceStreaming : public Service {
  public:
   std::string channel_name_;
   std::string account_;
+
+ protected:
+  ServiceStreaming(const ServiceStreaming &) = default;
+  ServiceStreaming(ServiceStreaming &&) = default;
+  ServiceStreaming &operator=(const ServiceStreaming &) = default;
+  ServiceStreaming &operator=(ServiceStreaming &&) = default;
 };
 
 class ServiceRtns : public Service {
@@ -179,6 +217,10 @@ class ServiceRtns : public Service {
   virtual std::string PackService() override { return Pack(this); }
   virtual void UnpackService(Unpacker *unpacker) override { *unpacker >> this; }
 
+  virtual std::unique_ptr<Service> Clone() const {
+    return std::unique_ptr<Service>(new ServiceRtns(*this));
+  }
+
   friend agora::tools::Packer &operator<<(agora::tools::Packer &p,
                                           const ServiceRtns *x) {
     return p << dynamic_cast<const Service *>(x);
@@ -187,6 +229,12 @@ class ServiceRtns : public Service {
                                             ServiceRtns *x) {
     return p >> dynamic_cast<Service *>(x);
   }
+
+ protected:
+  ServiceRtns(const ServiceRtns &) = default;
+  ServiceRtns(ServiceRtns &&) = default;
+  ServiceRtns &operator=(const ServiceRtns &) = default;
+  ServiceRtns &operator=(ServiceRtns &&) = default;
 };
 
 template <class T>

--- a/DynamicKey/AgoraDynamicKey/cpp/test/AccessToken2_test.cpp
+++ b/DynamicKey/AgoraDynamicKey/cpp/test/AccessToken2_test.cpp
@@ -60,11 +60,18 @@ class AccessToken2_test : public testing::Test {
   void VerifyServiceStreaming(Service *l, Service *r) {
     VerifyService(l, r);
 
-    auto l_rtc = dynamic_cast<ServiceRtc *>(l);
-    auto r_rtc = dynamic_cast<ServiceRtc *>(r);
+    auto l_rtc = dynamic_cast<ServiceStreaming *>(l);
+    auto r_rtc = dynamic_cast<ServiceStreaming *>(r);
 
     EXPECT_EQ(l_rtc->channel_name_, r_rtc->channel_name_);
     EXPECT_EQ(l_rtc->account_, r_rtc->account_);
+  }
+
+  void VerifyServiceRtns(Service *l, Service *r) {
+    VerifyService(l, r);
+
+    (void)dynamic_cast<ServiceRtns *>(l);
+    (void)dynamic_cast<ServiceRtns *>(r);
   }
 
   void VerifyAccessToken2(const std::string &expected, AccessToken2 *key) {
@@ -96,6 +103,7 @@ class AccessToken2_test : public testing::Test {
         {ServiceRtm::kServiceType, &AccessToken2_test::VerifyServiceRtm},
         {ServiceStreaming::kServiceType,
          &AccessToken2_test::VerifyServiceStreaming},
+        {ServiceRtns::kServiceType, &AccessToken2_test::VerifyServiceRtns},
     };
 
     auto k7_it = k7.services_.begin();
@@ -176,14 +184,25 @@ class AccessToken2_test : public testing::Test {
     std::unique_ptr<Service> rtm(new ServiceRtm(user_id_));
     rtm->AddPrivilege(ServiceRtm::kPrivilegeLogin, expire_);
 
+    std::unique_ptr<Service> streaming(
+        new ServiceStreaming(channel_name_, uid_));
+    streaming->AddPrivilege(ServiceStreaming::kPrivilegePublishMixStream,
+                            expire_);
+    streaming->AddPrivilege(ServiceStreaming::kPrivilegePublishRawStream,
+                            expire_);
+
+    std::unique_ptr<Service> rtns(new ServiceRtns());
+
     key.AddService(std::move(rtc));
     key.AddService(std::move(rtm));
+    key.AddService(std::move(streaming));
+    key.AddService(std::move(rtns));
 
     std::string expected =
-        "007eJxTYOAQsrQ5s3TfH+"
-        "1tvy8zZZ46EpCc0V43JXdGd2jS8porKo4KDJbmBs6OxqYpqWYGySYmZiamSUmJqRaJRoam"
-        "BmaGScbG7l8EGCKYGBgYGRgYmIAkCxCD+ExgkhlMsoBJBQbzFHMjYzPT1CRLC2MTC1NjS/"
-        "NU41TjNMsUEzODpJSURC4GIwsLI2MTQyNzY5BZEJM4GUpSi0viS4tTiwAipyp4";
+        "007eJxTYFgedFLiTXNWtuzC7DTnrFeCpxKDp+r3eVnVrrEK9M+vm6/"
+        "AYGlu4OxobJqSamaQbGJiZmKalJSYapFoZGhqYGaYZGzs/"
+        "kWAIYKJgYGRgYGBBUiCMIjPBCaZwSQLmFRgME8xNzI2M01NsrQwNrEwNbY0TzVONU6zTDE"
+        "xM0hKSUnkYjCysDAyNjE0MjdmApoDMYmToSS1uCS+tDi1iJmBCcV40oxkAToRACRUNJQ=";
     VerifyAccessToken2(expected, &key);
   }
 

--- a/DynamicKey/AgoraDynamicKey/python3/src/AccessToken2.py
+++ b/DynamicKey/AgoraDynamicKey/python3/src/AccessToken2.py
@@ -109,11 +109,26 @@ class ServiceStreaming(Service):
         return buffer
 
 
+class ServiceRtns(Service):
+    kServiceType = 4
+
+    def __init__(self):
+        super(ServiceRtns, self).__init__(ServiceRtns.kServiceType)
+
+    def pack(self):
+        return super(ServiceRtns, self).pack()
+
+    def unpack(self, buffer):
+        buffer = super(ServiceRtns, self).unpack(buffer)
+        return buffer
+
+
 class AccessToken:
     kServices = {
         ServiceRtc.kServiceType: ServiceRtc,
         ServiceRtm.kServiceType: ServiceRtm,
-        ServiceStreaming.kServiceType: ServiceStreaming
+        ServiceStreaming.kServiceType: ServiceStreaming,
+        ServiceRtns.kServiceType: ServiceRtns
     }
 
     def __init__(self, app_id='', app_certificate='', issue_ts=0, expire=900):

--- a/DynamicKey/AgoraDynamicKey/python3/test/AccessToken2Test.py
+++ b/DynamicKey/AgoraDynamicKey/python3/test/AccessToken2Test.py
@@ -68,12 +68,20 @@ class AccessToken2Test(unittest.TestCase):
         rtm = ServiceRtm(self.__user_id)
         rtm.add_privilege(ServiceRtm.kPrivilegeLogin, self.__expire)
 
+        streaming = ServiceStreaming(self.__channel_name, self.__uid)
+        streaming.add_privilege(ServiceStreaming.kPrivilegePublishMixStream, self.__expire)
+        streaming.add_privilege(ServiceStreaming.kPrivilegePublishRawStream, self.__expire)
+
+        rtns = ServiceRtns()
+
         self.__token.add_service(rtc)
         self.__token.add_service(rtm)
+        self.__token.add_service(streaming)
+        self.__token.add_service(rtns)
         result = self.__token.build()
 
-        expected = '007eJxTYOAQsrQ5s3TfH+1tvy8zZZ46EpCc0V43JXdGd2jS8porKo4KDJbmBs6OxqYpqWYGySYmZiamSUmJqRaJRoamBma' \
-                   'GScbG7l8EGCKYGBgYGRgYmIAkCxCD+ExgkhlMsoBJBQbzFHMjYzPT1CRLC2MTC1NjS/NU41TjNMsUEzODpJSURC4GIwsLI' \
-                   '2MTQyNzY5BZEJM4GUpSi0viS4tTiwAipyp4'
+        expected = '007eJxTYFgedFLiTXNWtuzC7DTnrFeCpxKDp+r3eVnVrrEK9M+vm6/AYGlu4OxobJqSamaQbGJiZmKalJSYapFoZGhqYG' \
+                   'aYZGzs/kWAIYKJgYGRgYGBBUiCMIjPBCaZwSQLmFRgME8xNzI2M01NsrQwNrEwNbY0TzVONU6zTDExM0hKSUnkYjCysDA' \
+                   'yNjE0MjdmApoDMYmToSS1uCS+tDi1iJmBCcV40oxkAToRACRUNJQ='
         self.assertEqual(expected, result)
 


### PR DESCRIPTION
|Service| has value semantic and its copy & move constructor should not be deleted.