### PR TITLE
[ERR_INVALID_ARG_TYPE] : fix for wrong argument passed 

### DIFF
--- a/DynamicKey/AgoraDynamicKey/nodejs/index.d.ts
+++ b/DynamicKey/AgoraDynamicKey/nodejs/index.d.ts
@@ -53,15 +53,13 @@ export namespace RtmTokenBuilder {
      * @param {*} appCertificate:	Certificate of the application that you registered in 
      *                 the Agora Dashboard. See Get an App Certificate.
      * @param {*} account: The user account. 
-     * @param {*} role : Role_Publisher = 1: A broadcaster (host) in a live-broadcast profile.
-     *      Role_Subscriber = 2: (Default) A audience in a live-broadcast profile.
      * @param {*} privilegeExpiredTs : represented by the number of seconds elapsed since 
      *                   1/1/1970. If, for example, you want to access the
      *                   Agora Service within 10 minutes after the token is 
      *                   generated, set expireTimestamp as the current 
      * @return token
      */
-    export function buildToken(appID: string, appCertificate: string, account: string | number, role: number, privilegeExpiredTs: number): string;
+    export function buildToken(appID: string, appCertificate: string, account: string | number, privilegeExpiredTs: number): string;
 
 }
 

--- a/DynamicKey/AgoraDynamicKey/nodejs/package-lock.json
+++ b/DynamicKey/AgoraDynamicKey/nodejs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-access-token",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/DynamicKey/AgoraDynamicKey/nodejs/src/RtmTokenBuilder.js
+++ b/DynamicKey/AgoraDynamicKey/nodejs/src/RtmTokenBuilder.js
@@ -12,16 +12,14 @@ class RtmTokenBuilder {
    * @param {*} appCertificate:	Certificate of the application that you registered in 
    *                 the Agora Dashboard. See Get an App Certificate.
    * @param {*} account: The user account. 
-   * @param {*} role : Role_Publisher = 1: A broadcaster (host) in a live-broadcast profile.
-   *      Role_Subscriber = 2: (Default) A audience in a live-broadcast profile.
    * @param {*} privilegeExpiredTs : represented by the number of seconds elapsed since 
    *                   1/1/1970. If, for example, you want to access the
    *                   Agora Service within 10 minutes after the token is 
    *                   generated, set expireTimestamp as the current 
    * @return token
    */
-  static buildToken (appID, appCertificate, account, role, privilegeExpiredTs) {
-    const key = new AccessToken(appID, appCertificate, account, "")
+  static buildToken(appID, appCertificate, account, privilegeExpiredTs) {
+    const key = new AccessToken(appID, appCertificate, '', account)
     key.addPriviledge(Priviledges.kRtmLogin, privilegeExpiredTs)
     return key.build()
   }


### PR DESCRIPTION
`TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type number (1617791410581)`

The `AccessToken` function in `AccessToken.js`

`var AccessToken = function (appID, appCertificate, channelName, uid) ` takes 3rd parameter as channel name.
But class `RtmTokenBuilder`'s `buildToken` function passes `account` as a 3rd parameter (account is a `number` type) to `AccessToken`  [line 24](https://github.com/AgoraIO/Tools/blob/a27ccdd7bf29463f2755c8fa16e82efc1a366f59/DynamicKey/AgoraDynamicKey/nodejs/src/RtmTokenBuilder.js#L24)

As this 3rd parameter is `channelName` a `number` type is passed to `string` type.

Code fails to extract buffer at [line32](https://github.com/AgoraIO/Tools/blob/a27ccdd7bf29463f2755c8fa16e82efc1a366f59/DynamicKey/AgoraDynamicKey/nodejs/src/AccessToken.js#L32) 
