### PR TITLE
'import struct' needed to prevent NameError at python3

### DIFF
--- a/DynamicKey/AgoraDynamicKey/python3/src/AccessToken.py
+++ b/DynamicKey/AgoraDynamicKey/python3/src/AccessToken.py
@@ -4,6 +4,8 @@ import base64
 import random
 import warnings
 
+import struct #added line
+
 from zlib import crc32
 import secrets
 import time


### PR DESCRIPTION
Without this 'import struct' , Python interpreter throws an error of "NameError: name 'struct' is not defined". To solve this error, 'import struct' is needed.