### PR TITLE
Bugfix: change AccessToken call in RtmTokenBuilder.py

### DIFF
--- a/DynamicKey/AgoraDynamicKey/python3/src/RtmTokenBuilder.py
+++ b/DynamicKey/AgoraDynamicKey/python3/src/RtmTokenBuilder.py
@@ -19,6 +19,6 @@ class RtmTokenBuilder:
     #                    timestamp + 600 (seconds)./
     @staticmethod
     def buildToken(appId, appCertificate, userAccount, role, privilegeExpiredTs):
-        token = AccessToken(appId, appCertificate, userAccount, "")
+        token = AccessToken(appId, appCertificate, "", userAccount)
         token.addPrivilege(kRtmLogin, privilegeExpiredTs)
         return token.build()


### PR DESCRIPTION
Regarding to a thread in the Agora-Dev Slack-channel: https://agoraiodev.slack.com/archives/CPQP4GMJ9/p1625491481455400?thread_ts=1623209902.170000&cid=CPQP4GMJ9
 
These are the code changes to make the RtmTokenBuilder.py return a valid token. The problem was that the call to AccessToken in RtmTokenBuilder was wrong.