### PR TITLE
fix(DynamicKey/python3): Adds missing struct import in AccessToken.py

### DIFF
--- a/DynamicKey/AgoraDynamicKey/python3/src/AccessToken.py
+++ b/DynamicKey/AgoraDynamicKey/python3/src/AccessToken.py
@@ -2,6 +2,7 @@ import hmac
 from hashlib import sha256
 import base64
 import random
+import struct
 import warnings
 
 from zlib import crc32


### PR DESCRIPTION
Adds a missing import for the `struct` library in the python3 AccessToken module.