### PR TITLE
Examples of official documents, no distinction between mic authentication

### DIFF
--- a/DynamicKey/AgoraDynamicKey/php/sample/RtcTokenBuilderSample.php
+++ b/DynamicKey/AgoraDynamicKey/php/sample/RtcTokenBuilderSample.php
@@ -16,4 +16,12 @@ echo 'Token with int uid: ' . $token . PHP_EOL;
 
 $token = RtcTokenBuilder::buildTokenWithUserAccount($appID, $appCertificate, $channelName, $uidStr, $role, $privilegeExpiredTs);
 echo 'Token with user account: ' . $token . PHP_EOL;
+
+/**
+ * Whether to connect the microphone
+ * isConnectMicrophone 1=yes 0=no
+ */
+$token = RtcTokenBuilder::buildTokenWithUid($appID, $appCertificate, $channelName, $uid, $role, $privilegeExpiredTs,1);
+echo 'Token with int uid: ' . $token . PHP_EOL;
+
 ?>

--- a/DynamicKey/AgoraDynamicKey/php/sample/RtcTokenBuilderSample.php
+++ b/DynamicKey/AgoraDynamicKey/php/sample/RtcTokenBuilderSample.php
@@ -18,7 +18,7 @@ $token = RtcTokenBuilder::buildTokenWithUserAccount($appID, $appCertificate, $ch
 echo 'Token with user account: ' . $token . PHP_EOL;
 
 /**
- * Whether to connect the microphone
+ * Whether to connect the microphone authentication
  * isConnectMicrophone 1=yes 0=no
  */
 $token = RtcTokenBuilder::buildTokenWithUid($appID, $appCertificate, $channelName, $uid, $role, $privilegeExpiredTs,1);

--- a/DynamicKey/AgoraDynamicKey/php/src/RtcTokenBuilder.php
+++ b/DynamicKey/AgoraDynamicKey/php/src/RtcTokenBuilder.php
@@ -23,7 +23,7 @@ class RtcTokenBuilder
     #                    Agora Service within 10 minutes after the token is 
     #                    generated, set expireTimestamp as the current 
     #                    timestamp + 600 (seconds)./
-    # isConnectMicrophone Whether to connect the microphone 1=yes 0=no
+    # Whether to connect the microphone authentication 1=yes 0=no
     public static function buildTokenWithUid($appID, $appCertificate, $channelName, $uid, $role, $privilegeExpireTs, $isConnectMicrophone = 0)
     {
         return RtcTokenBuilder::buildTokenWithUserAccount($appID, $appCertificate, $channelName, $uid, $role, $privilegeExpireTs, $isConnectMicrophone);


### PR DESCRIPTION
The official document example, there is no distinction between the authentication of the microphone, resulting in the failure of the generation of the ordinary joining channel, and the remote master and apprentice cannot be set