### PR TITLE
Corrected AccessToken2.py build() service items order

### DIFF
--- a/DynamicKey/AgoraDynamicKey/python3/src/AccessToken2.py
+++ b/DynamicKey/AgoraDynamicKey/python3/src/AccessToken2.py
@@ -201,7 +201,7 @@ class AccessToken:
         signing_info = pack_string(self.__app_id) + pack_uint32(self.__issue_ts) + pack_uint32(self.__expire) + \
                        pack_uint32(self.__salt) + pack_uint16(len(self.__service))
 
-        for _, service in self.__service.items():
+        for _, service in sorted(self.__service.items(), key=lambda x: x[0]):
             signing_info += service.pack()
 
         signature = hmac.new(signing, signing_info, sha256).digest()


### PR DESCRIPTION
Hi,
In the Python3 `AccessToken2` implementation, when calling `build()`, the services are not sorted by type and causes the token to be invalid.
We have compared with the Java implementation.

**Java**: services is sorted thanks to `TreeMap` structure
```
public Map<Short, Service> services = new TreeMap<>();
...
public String build() throws Exception {
...
    this.services.forEach((k, v) -> {
        v.pack(buf);
    });
...
}
```

**Python3**: services is not sorted due to Python `dict` structure
```
self.__service = {}
...
def build(self):
...
    // service is not sorted because it's a Python dict
    for _, service in self.__service.items():
        signing_info += service.pack()
...
```

So I added `sorted()` method call to order `service` by type in `build()`.
