### PR TITLE
fix syntax error of Array#pack directives

### DIFF
--- a/DynamicKey/AgoraDynamicKey/ruby/src/dynamic_key5.rb
+++ b/DynamicKey/AgoraDynamicKey/ruby/src/dynamic_key5.rb
@@ -165,15 +165,15 @@ module DynamicKey5
   end
 
   def pack_uint16(x)
-    [x].pack('<S')
+    [x].pack('S<')
   end
 
   def pack_uint32(x)
-    [x].pack('<I')
+    [x].pack('I<')
   end
 
   def pack_int32(x)
-    [x].pack('<i')
+    [x].pack('i<')
   end
 
   def pack_string(string)


### PR DESCRIPTION
Fixes https://github.com/AgoraIO/Tools/issues/326

Tweaks minor mistakes of the `<` directive of `Array#pack`, which causes the following warning message in Ruby3.2.1

```ruby
<internal:pack>:8: warning: unknown pack directive '<' in '<S'
```