### PR TITLE
fix(): DotNetZip has vulnerabilities, use SharpZipLib as a replacemen…

### DIFF
--- a/DynamicKey/AgoraDynamicKey/csharp/src/AgoraIO/AgoraIO.csproj
+++ b/DynamicKey/AgoraDynamicKey/csharp/src/AgoraIO/AgoraIO.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
 
 </Project>

--- a/DynamicKey/AgoraDynamicKey/csharp/src/AgoraIO/Utils/Utils.cs
+++ b/DynamicKey/AgoraDynamicKey/csharp/src/AgoraIO/Utils/Utils.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using System.IO;
-using Ionic.Zlib;
+using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 
 namespace AgoraIO.Media
 {
@@ -56,7 +56,7 @@ namespace AgoraIO.Media
             byte[] output;
             using (MemoryStream outputStream = new MemoryStream())
             {
-                using (var zlibStream = new ZlibStream(outputStream, CompressionMode.Compress, CompressionLevel.Level5, true)) // or use Level6
+                using (var zlibStream = new DeflaterOutputStream(outputStream))
                 {
                     zlibStream.Write(data, 0, data.Length);
                 }
@@ -69,11 +69,12 @@ namespace AgoraIO.Media
         public static byte[] decompress(byte[] data)
         {
             byte[] output;
+            using (MemoryStream inputStream = new MemoryStream(data))
             using (MemoryStream outputStream = new MemoryStream())
             {
-                using (var zlibStream = new ZlibStream(outputStream, CompressionMode.Decompress))
+                using (var zlibStream = new InflaterInputStream(inputStream))
                 {
-                    zlibStream.Write(data, 0, data.Length);
+                    zlibStream.CopyTo(outputStream);
                 }
                 output = outputStream.ToArray();
             }

--- a/DynamicKey/AgoraDynamicKey/csharp/test/AgoraIO.Tests/AccessToken2Test.cs
+++ b/DynamicKey/AgoraDynamicKey/csharp/test/AgoraIO.Tests/AccessToken2Test.cs
@@ -57,7 +57,7 @@ namespace AgoraIO.Tests
             Assert.Equal(uidStr, serviceRtc._uid);
 
             string token = accessToken.build();
-            Assert.Equal("007eJxTYBBbsMMnKq7p9Hf/HcIX5kce9b518kCiQgSr5Zrp4X1Tu6UUGCzNDZwdjU1TUs0Mkk1MzExMk5ISUy0SjQxNDcwMk4yN3b8IMEQwMTAwMoAwBIL4CgzmKeZGxmamqUmWFsYmFqbGluapxqnGaZYpJmYGSSkpiVwMRhYWRsYmhkbmxgDCaiTj", token);
+            Assert.Equal("007eJwlx6EKQjEUgOGjYDEJgsG0R9h2zrazKAaDgtGrQdg880Gsgk2M+gA+wI0Wg1jMPodglYv8/OFTMLjUs9V69/zO6/7rvLxP349bUlUnXk+Lw3E/VBCDHo/QSfF6Q+TJ5ZwKJ2uc9iYjTj49qNoALWj+11hBkGDRu5IjI7HDGAoW3EYhr7NI6oJltkjGBvwBwmok4w==", token);
         }
 
         [Fact]
@@ -152,8 +152,9 @@ namespace AgoraIO.Tests
             Assert.Equal(uidStr, serviceRtc._uid);
             Assert.Equal(userId, serviceRtm._userId);
 
-            string expected = "007eJxTYPg19dsX8xO2Nys/bpSeoH/0j9CvSs1JWib9291PKC53l85UYLA0N3B2NDZNSTUzSDYxMTMxTUpKTLVINDI0NTAzTDI2dv8iwBDBxMDAyMDAwAwkWYAYxGcCk8xgkgVMKjCYp5gbGZuZpiZZWhibWJgaW5qnGqcap1mmmJgZJKWkJHIxGFlYGBmbGBqZGzMBzYGYxMlQklpcEl9anFrEChdEVgoAw6ct/Q==";
+            string expected = "007eJxNjD0KwkAUhJ8xFlqJbZpYauNm3/4WFmKRK9hJ1l3B1sQip1AEz2Bt5QmEXMFjCMEiWBgjiMV8MMPwhVCdnqUspvf8cQkOk9trUOWj45jtr3ExPMfBJgQtyXyG3DpBVowJxo1JnEpoxImIDGJc9mHhAbQAoF3Tr/PpXsN2Q79hCNJKioI7oxUyxVFLhw7X2jJBjLVJD6hSFFlEJXq152vqQubSbLlL3bbzG/+vb8OnLf0=";
             string token = accessToken.build();
+
             Assert.Equal(expected, token);
         }
 


### PR DESCRIPTION
DotNetZip has vulnerabilities, use SharpZipLib as a replacement. https://app.opencve.io/cve/CVE-2024-48510