### PR TITLE
Fix: Ensure full read in unPackString using io.ReadFull()

### DIFF
--- a/DynamicKey/AgoraDynamicKey/go/src/accesstoken2/util.go
+++ b/DynamicKey/AgoraDynamicKey/go/src/accesstoken2/util.go
@@ -127,7 +127,10 @@ func unPackString(r io.Reader) (s string, err error) {
 	}
 
 	buf := make([]byte, n)
-	r.Read(buf)
+	if _, err = io.ReadFull(r, buf); err != nil {
+		return
+	}
+
 	s = string(buf)
 	return
 }


### PR DESCRIPTION
r.Read(buf) was previously used in unPackString, but this does not guarantee that the full expected number of bytes (n) is read.
This could lead to incomplete string reads without detecting an error.

This PR replaces r.Read(buf) with io.ReadFull(r, buf), ensuring that either all n bytes are read or an error is returned.
This follows Go's best practices for error handling and improves the robustness of the function.